### PR TITLE
adjust to be capital letters on new game

### DIFF
--- a/unity/Assets/Scripts/LevelController.cs
+++ b/unity/Assets/Scripts/LevelController.cs
@@ -71,7 +71,7 @@ public class LevelController : MonoBehaviour
         StringBuilder sessionName = new StringBuilder();
         for (int i = 0; i < 5; i++)
         {
-            int randomNumber = Random.Range(97, 123); // CAPITAL ALPHABETIC
+            int randomNumber = Random.Range(65, 91); // CAPITAL ALPHABETIC
             sessionName.Append((char)randomNumber);
         }
 


### PR DESCRIPTION
adjust ASCII value range to be capital letters as intended when generating a new random session name